### PR TITLE
fix: Set default value in StringField to an empty string

### DIFF
--- a/Composer/packages/extensions/adaptive-form/src/components/fields/StringField.tsx
+++ b/Composer/packages/extensions/adaptive-form/src/components/fields/StringField.tsx
@@ -11,7 +11,7 @@ import { FieldLabel } from '../FieldLabel';
 export const StringField: React.FC<FieldProps<string>> = function StringField(props) {
   const {
     id,
-    value,
+    value = '',
     onChange,
     depth,
     disabled,


### PR DESCRIPTION
## Description
Set the default value for the `StringField` component's `value` prop to an empty string so an `undefined` value will not be passed to the `TextField`.

![image](https://user-images.githubusercontent.com/17039790/74991139-0049fe00-53fa-11ea-92af-b26f45e7a244.png)

